### PR TITLE
ユーザー登録仕様変更

### DIFF
--- a/laravel/.gitignore
+++ b/laravel/.gitignore
@@ -10,4 +10,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
-webpack.mix.js
+mix-manifest.json

--- a/laravel/.gitignore
+++ b/laravel/.gitignore
@@ -10,3 +10,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+webpack.mix.js

--- a/laravel/app/Http/Controllers/Auth/RegisterController.php
+++ b/laravel/app/Http/Controllers/Auth/RegisterController.php
@@ -52,6 +52,7 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
+            'own_id' => ['required', 'string', 'min:1', 'max:16', 'unique:users','regex:/^@[a-zA-Z0-9]+$/'],
             'name' => ['required', 'string', 'min:1', 'max:16'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             //alpha_numで英数字かチェック。
@@ -68,6 +69,7 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         return User::create([
+            'own_id' => $data['own_id'],
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -16,7 +16,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+      'own_id', 'name', 'email', 'password',
     ];
 
     /**

--- a/laravel/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/laravel/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,6 +15,7 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('own_id')->unique();
             $table->string('name');
             $table->string('email')->unique();
             //nullableでカラムにnullが入ることを許容

--- a/laravel/public/css/app.css
+++ b/laravel/public/css/app.css
@@ -14,7 +14,7 @@
 }
 
 .title-p_auto {
-  padding: 1rem;
+  padding: 2rem;
 }
 
 .search-form {

--- a/laravel/public/mix-manifest.json
+++ b/laravel/public/mix-manifest.json
@@ -1,4 +1,0 @@
-{
-    "/js/app.js": "/js/app.js?id=bb7d2d9fe1c926fe818e",
-    "/css/app.css": "/css/app.css?id=68d9a308d69680687e58"
-}

--- a/laravel/resources/lang/ja/validation.php
+++ b/laravel/resources/lang/ja/validation.php
@@ -147,6 +147,7 @@ return [
 
     //項目名を日本語化
     'attributes' => [
+      'own_id' => 'ユーザーID',
       'name' => 'ユーザー名',
       'email' => 'メールアドレス',
       'password' => 'パスワード',

--- a/laravel/resources/sass/common_nav.scss
+++ b/laravel/resources/sass/common_nav.scss
@@ -11,7 +11,7 @@
   border-radius: 4px;
 }
 .title-p_auto{
-  padding: 1rem;
+  padding: 2rem;
 }
 .search-form{
   margin: 0 auto;

--- a/laravel/resources/views/auth/login.blade.php
+++ b/laravel/resources/views/auth/login.blade.php
@@ -27,12 +27,8 @@
                   <input class="form-control" type="password" id="password" name="password" required>
                 </div>
  
-                {{--ここから--}}
                 <input type="hidden" name="remember" id="remember" value="on">
-                {{--ここまで--}}
-
                 <button class="btn btn-block blue-gradient mt-2 mb-2" type="submit">ログイン</button>
-
               </form>
 
               <div class="mt-0">

--- a/laravel/resources/views/auth/register.blade.php
+++ b/laravel/resources/views/auth/register.blade.php
@@ -15,6 +15,12 @@
               <form method="POST" action="{{ route('register') }}">
                 @csrf
                 <div class="md-form">
+                  <label for="own_id">ユーザーID</label>
+                  <!-- old関数を使うことで、入力した内容が保持された状態でユーザー登録画面を表示 -->
+                  <input class="form-control" type="text" id="own_id" name="own_id" required value="{{ old('own_id') }}">
+                  <small>@+半角英数字の16文字以内で入力して下さい。</small>
+                </div>
+                <div class="md-form">
                   <label for="name">ユーザー名</label>
                   <!-- old関数を使うことで、入力した内容が保持された状態でユーザー登録画面を表示 -->
                   <input class="form-control" type="text" id="name" name="name" required value="{{ old('name') }}">
@@ -27,6 +33,7 @@
                 <div class="md-form">
                   <label for="password">パスワード</label>
                   <input class="form-control" type="password" id="password" name="password" required>
+                  <small>パスワードは半角英数字の8文字以内で入力して下さい。</small>
                 </div>
                 <div class="md-form">
                   <label for="password_confirmation">パスワード(確認)</label>


### PR DESCRIPTION
#What
ユーザー登録にユーザーIDも取り入れるようにする


#Why
今まではユーザーは名前とメールを登録すれば良かったが、それだと名前が被って誰だか分からなくなったりするため